### PR TITLE
Allow for custom ordering of events

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -776,6 +776,20 @@ class Calendar extends React.Component {
      * or custom `Function(events, minimumStartDifference, slotMetrics, accessors)`
      */
     dayLayoutAlgorithm: DayLayoutAlgorithmPropType,
+
+    /**
+     * Custom sorting options that can overwrite the default * algorithm for ordering events within a date cell.
+     * `sortPriority` defines a list of string keys that
+     * controls the sort order.
+     * `customComparators` define an object whose keys should
+     * match any non-default sorting functions. (By default,
+     * only `startDay', 'duration', 'allDay', and
+     * 'startTime' functions are provided).
+     */
+    customSorting: PropTypes.shape({
+      sortPriority: PropTypes.arrayOf(PropTypes.string),
+      customComparators: PropTypes.object,
+    }),
   }
 
   static defaultProps = {

--- a/src/Month.js
+++ b/src/Month.js
@@ -120,6 +120,7 @@ class MonthView extends React.Component {
       showAllEvents,
       infiniteScroll,
       expandRow,
+      customSorting,
     } = this.props
 
     const flexibleRowHeight = infiniteScroll || expandRow
@@ -130,7 +131,7 @@ class MonthView extends React.Component {
 
     events = eventsForWeek(events, week[0], week[week.length - 1], accessors)
 
-    events.sort((a, b) => sortEvents(a, b, accessors))
+    events.sort((a, b) => sortEvents(a, b, accessors, customSorting))
 
     const rowContainer = (
       <DateContentRow
@@ -388,6 +389,11 @@ MonthView.propTypes = {
       y: PropTypes.number,
     }),
   ]),
+
+  customSorting: PropTypes.shape({
+    sortPriority: PropTypes.arrayOf(PropTypes.string),
+    customComparators: PropTypes.object,
+  }),
 }
 
 MonthView.range = (date, { localizer }) => {

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -166,6 +166,7 @@ export default class TimeGrid extends Component {
       showMultiDayTimes,
       longPressThreshold,
       resizable,
+      customSorting,
     } = this.props
 
     width = width || this.state.gutterWidth
@@ -195,7 +196,7 @@ export default class TimeGrid extends Component {
       }
     })
 
-    allDayEvents.sort((a, b) => sortEvents(a, b, accessors))
+    allDayEvents.sort((a, b) => sortEvents(a, b, accessors, customSorting))
 
     return (
       <div
@@ -347,6 +348,11 @@ TimeGrid.propTypes = {
   getDrilldownView: PropTypes.func.isRequired,
 
   dayLayoutAlgorithm: DayLayoutAlgorithmPropType,
+
+  customSorting: PropTypes.shape({
+    sortPriority: PropTypes.arrayOf(PropTypes.string),
+    customComparators: PropTypes.object,
+  }),
 }
 
 TimeGrid.defaultProps = {

--- a/src/utils/DayEventLayout.js
+++ b/src/utils/DayEventLayout.js
@@ -2,14 +2,11 @@
 
 import overlap from './layout-algorithms/overlap'
 import noOverlap from './layout-algorithms/no-overlap'
+import { isFunction } from './helpers'
 
 const DefaultAlgorithms = {
   overlap: overlap,
   'no-overlap': noOverlap,
-}
-
-function isFunction(a) {
-  return !!(a && a.constructor && a.call && a.apply)
 }
 
 //

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -19,3 +19,7 @@ export function isFirstFocusedRender(component) {
     (component.state.focused && (component._firstFocus = true))
   )
 }
+
+export function isFunction(a) {
+  return !!(a && a.constructor && a.call && a.apply)
+}


### PR DESCRIPTION
Add prop `customSorting` to Calendar. This prop is an object
which accepts 2 possible keys:
- `sortPriority` determines the order of functions to run
to determine the order of events
- `customComparators` provides custom functions to run