### PR TITLE
Update `ceil` function to handle midnight dates

### DIFF
--- a/src/addons/dragAndDrop/WeekWrapper.js
+++ b/src/addons/dragAndDrop/WeekWrapper.js
@@ -15,10 +15,6 @@ const eventTimes = (event, accessors) => {
   let start = accessors.start(event)
   let end = accessors.end(event)
 
-  const isZeroDuration =
-    dates.eq(start, end, 'minutes') && start.getMinutes() === 0
-  // make zero duration midnight events at least one day long
-  if (isZeroDuration) end = dates.add(end, 1, 'day')
   return { start, end }
 }
 

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -63,7 +63,7 @@ export function visibleDays(date, localizer) {
 export function ceil(date, unit) {
   let floor = dates.startOf(date, unit)
 
-  return dates.eq(floor, date) ? floor : dates.add(floor, 1, unit)
+  return dates.add(floor, 1, unit)
 }
 
 export function range(start, end, unit = 'day') {


### PR DESCRIPTION
This function now always adds a day to the end of the date.
Previously, this would make an exception for dates that
have a time of 12:00 AM and would return the current date,
rather than add an extra date.