### PR TITLE
Revert "Add new Calendar prop: `componentProps`"

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -342,6 +342,14 @@ class Calendar extends React.Component {
     onShowMore: PropTypes.func,
 
     /**
+     * Displays all events on the month view instead of
+     * having some hidden behind +{count} more. This will
+     * cause the rows in the month view to be scrollable if
+     * the number of events exceed the height of the row.
+     */
+    showAllEvents: PropTypes.bool,
+
+    /**
      * The selected event, if any.
      */
     selected: PropTypes.object,

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -720,6 +720,24 @@ class Calendar extends React.Component {
     }),
 
     /**
+     * Provide custom props to custom components.
+     * The name of the key should match the name of the
+     * custom component.
+     * ```jsx
+     * let componentProps = {
+     *   toolbar: {
+     *    customToolbarProp1: value1,
+     *    customToolbarProp2: value2,
+     *   }
+     * }
+     * <Calendar componentProps={componentProps} />
+     * ```
+     */
+    componentProps: PropTypes.shape({
+      toolbar: PropTypes.object,
+    }),
+
+    /**
      * String messages used throughout the component, override to provide localizations
      */
     messages: PropTypes.shape({
@@ -802,6 +820,7 @@ class Calendar extends React.Component {
     culture,
     messages = {},
     components = {},
+    componentProps = {},
     formats = {},
   }) {
     let names = viewNames(views)
@@ -825,6 +844,7 @@ class Calendar extends React.Component {
         weekWrapper: NoopWrapper,
         timeSlotWrapper: NoopWrapper,
       }),
+      componentProps: componentProps,
       accessors: {
         start: wrapAccessor(startAccessor),
         end: wrapAccessor(endAccessor),
@@ -889,6 +909,7 @@ class Calendar extends React.Component {
       formats: _1,
       messages: _2,
       culture: _3,
+      componentProps: _4,
       ...props
     } = this.props
 
@@ -898,6 +919,7 @@ class Calendar extends React.Component {
     const {
       accessors,
       components,
+      componentProps,
       getters,
       localizer,
       viewNames,
@@ -914,6 +936,7 @@ class Calendar extends React.Component {
       >
         {toolbar && (
           <CalToolbar
+            {...componentProps.toolbar}
             date={current}
             view={view}
             views={viewNames}

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -728,24 +728,6 @@ class Calendar extends React.Component {
     }),
 
     /**
-     * Provide custom props to custom components.
-     * The name of the key should match the name of the
-     * custom component.
-     * ```jsx
-     * let componentProps = {
-     *   toolbar: {
-     *    customToolbarProp1: value1,
-     *    customToolbarProp2: value2,
-     *   }
-     * }
-     * <Calendar componentProps={componentProps} />
-     * ```
-     */
-    componentProps: PropTypes.shape({
-      toolbar: PropTypes.object,
-    }),
-
-    /**
      * String messages used throughout the component, override to provide localizations
      */
     messages: PropTypes.shape({
@@ -828,7 +810,6 @@ class Calendar extends React.Component {
     culture,
     messages = {},
     components = {},
-    componentProps = {},
     formats = {},
   }) {
     let names = viewNames(views)
@@ -852,7 +833,6 @@ class Calendar extends React.Component {
         weekWrapper: NoopWrapper,
         timeSlotWrapper: NoopWrapper,
       }),
-      componentProps: componentProps,
       accessors: {
         start: wrapAccessor(startAccessor),
         end: wrapAccessor(endAccessor),
@@ -917,7 +897,6 @@ class Calendar extends React.Component {
       formats: _1,
       messages: _2,
       culture: _3,
-      componentProps: _4,
       ...props
     } = this.props
 
@@ -927,7 +906,6 @@ class Calendar extends React.Component {
     const {
       accessors,
       components,
-      componentProps,
       getters,
       localizer,
       viewNames,
@@ -944,7 +922,6 @@ class Calendar extends React.Component {
       >
         {toolbar && (
           <CalToolbar
-            {...componentProps.toolbar}
             date={current}
             view={view}
             views={viewNames}

--- a/src/DateContentRow.js
+++ b/src/DateContentRow.js
@@ -71,10 +71,15 @@ class DateContentRow extends React.Component {
   }
 
   renderDummy = () => {
-    let { className, range, renderHeader } = this.props
+    let { className, range, renderHeader, showAllEvents } = this.props
     return (
       <div className={className}>
-        <div className="rbc-row-content">
+        <div
+          className={clsx(
+            'rbc-row-content',
+            showAllEvents && 'rbc-row-content-scrollable'
+          )}
+        >
           {renderHeader && (
             <div className="rbc-row" ref={this.createHeadingRef}>
               {range.map(this.renderHeadingCell)}
@@ -118,6 +123,7 @@ class DateContentRow extends React.Component {
       longPressThreshold,
       isAllDay,
       resizable,
+      showAllEvents,
     } = this.props
 
     if (renderForMeasure) return this.renderDummy()
@@ -159,24 +165,35 @@ class DateContentRow extends React.Component {
           resourceId={resourceId}
         />
 
-        <div className="rbc-row-content">
+        <div
+          className={clsx(
+            'rbc-row-content',
+            showAllEvents && 'rbc-row-content-scrollable'
+          )}
+        >
           {renderHeader && (
             <div className="rbc-row " ref={this.createHeadingRef}>
               {range.map(this.renderHeadingCell)}
             </div>
           )}
-          <WeekWrapper isAllDay={isAllDay} {...eventRowProps}>
-            {levels.map((segs, idx) => (
-              <EventRow key={idx} segments={segs} {...eventRowProps} />
-            ))}
-            {!!extra.length && (
-              <EventEndingRow
-                segments={extra}
-                onShowMore={this.handleShowMore}
-                {...eventRowProps}
-              />
+          <div
+            className={clsx(
+              showAllEvents && 'rbc-row-content-scroll-container'
             )}
-          </WeekWrapper>
+          >
+            <WeekWrapper isAllDay={isAllDay} {...eventRowProps}>
+              {levels.map((segs, idx) => (
+                <EventRow key={idx} segments={segs} {...eventRowProps} />
+              ))}
+              {!!extra.length && (
+                <EventEndingRow
+                  segments={extra}
+                  onShowMore={this.handleShowMore}
+                  {...eventRowProps}
+                />
+              )}
+            </WeekWrapper>
+          </div>
         </div>
       </div>
     )
@@ -200,6 +217,7 @@ DateContentRow.propTypes = {
   longPressThreshold: PropTypes.number,
 
   onShowMore: PropTypes.func,
+  showAllEvents: PropTypes.bool,
   onSelectSlot: PropTypes.func,
   onSelect: PropTypes.func,
   onSelectEnd: PropTypes.func,

--- a/src/Month.js
+++ b/src/Month.js
@@ -102,6 +102,7 @@ class MonthView extends React.Component {
       longPressThreshold,
       accessors,
       getters,
+      showAllEvents,
     } = this.props
 
     const { needLimitMeasure, rowLimit } = this.state
@@ -120,7 +121,7 @@ class MonthView extends React.Component {
         date={date}
         range={week}
         events={events}
-        maxRows={rowLimit}
+        maxRows={showAllEvents ? Infinity : rowLimit}
         selected={selected}
         selectable={selectable}
         components={components}
@@ -137,6 +138,7 @@ class MonthView extends React.Component {
         longPressThreshold={longPressThreshold}
         rtl={this.props.rtl}
         resizable={this.props.resizable}
+        showAllEvents={showAllEvents}
       />
     )
   }
@@ -342,6 +344,7 @@ MonthView.propTypes = {
   onDoubleClickEvent: PropTypes.func,
   onKeyPressEvent: PropTypes.func,
   onShowMore: PropTypes.func,
+  showAllEvents: PropTypes.bool,
   onDrillDown: PropTypes.func,
   getDrilldownView: PropTypes.func.isRequired,
 

--- a/src/addons/dragAndDrop/WeekWrapper.js
+++ b/src/addons/dragAndDrop/WeekWrapper.js
@@ -15,10 +15,6 @@ const eventTimes = (event, accessors) => {
   let start = accessors.start(event)
   let end = accessors.end(event)
 
-  const isZeroDuration =
-    dates.eq(start, end, 'minutes') && start.getMinutes() === 0
-  // make zero duration midnight events at least one day long
-  if (isZeroDuration) end = dates.add(end, 1, 'day')
   return { start, end }
 }
 

--- a/src/less/styles.less
+++ b/src/less/styles.less
@@ -81,6 +81,16 @@
   z-index: 4;
 }
 
+.rbc-row-content-scrollable {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+
+  .rbc-row-content-scroll-container {
+    overflow-y: scroll;
+  }
+}
+
 .rbc-today {
   background-color: @today-highlight-bg;
 }

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -80,6 +80,16 @@
   z-index: 4;
 }
 
+.rbc-row-content-scrollable {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+
+  .rbc-row-content-scroll-container {
+    overflow-y: scroll;
+  }
+}
+
 .rbc-today {
   background-color: $today-highlight-bg;
 }

--- a/src/sass/time-column.scss
+++ b/src/sass/time-column.scss
@@ -5,8 +5,6 @@
   flex-direction: column;
   min-height: 100%;
 
-  height: 100%; // ie-fix
-
   .rbc-timeslot-group {
     flex: 1;
   }

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -63,7 +63,7 @@ export function visibleDays(date, localizer) {
 export function ceil(date, unit) {
   let floor = dates.startOf(date, unit)
 
-  return dates.eq(floor, date) ? floor : dates.add(floor, 1, unit)
+  return dates.add(floor, 1, unit)
 }
 
 export function range(start, end, unit = 'day') {


### PR DESCRIPTION
Reverts jkhoang313/react-big-calendar#5

We can pass in component props directly by doing

```
toolbar: (props) => <Toolbar {...props} customProp={customProp}>
```