### PR TITLE
Remove `componentProps`

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -738,24 +738,6 @@ class Calendar extends React.Component {
     }),
 
     /**
-     * Provide custom props to custom components.
-     * The name of the key should match the name of the
-     * custom component.
-     * ```jsx
-     * let componentProps = {
-     *   toolbar: {
-     *    customToolbarProp1: value1,
-     *    customToolbarProp2: value2,
-     *   }
-     * }
-     * <Calendar componentProps={componentProps} />
-     * ```
-     */
-    componentProps: PropTypes.shape({
-      toolbar: PropTypes.object,
-    }),
-
-    /**
      * String messages used throughout the component, override to provide localizations
      */
     messages: PropTypes.shape({
@@ -853,7 +835,6 @@ class Calendar extends React.Component {
     culture,
     messages = {},
     components = {},
-    componentProps = {},
     formats = {},
   }) {
     let names = viewNames(views)
@@ -877,7 +858,6 @@ class Calendar extends React.Component {
         weekWrapper: NoopWrapper,
         timeSlotWrapper: NoopWrapper,
       }),
-      componentProps: componentProps,
       accessors: {
         start: wrapAccessor(startAccessor),
         end: wrapAccessor(endAccessor),
@@ -951,7 +931,6 @@ class Calendar extends React.Component {
       formats: _1,
       messages: _2,
       culture: _3,
-      componentProps: _4,
       ...props
     } = this.props
 
@@ -961,7 +940,6 @@ class Calendar extends React.Component {
     const {
       accessors,
       components,
-      componentProps,
       getters,
       localizer,
       viewNames,
@@ -978,7 +956,6 @@ class Calendar extends React.Component {
       >
         {toolbar && (
           <CalToolbar
-            {...componentProps.toolbar}
             date={current}
             view={view}
             views={viewNames}


### PR DESCRIPTION
We can pass in component props directly by doing:
```
toolbar: (props) => <Toolbar {...props} customProp={customProp}>
```