### PR TITLE
Create container for month rows

### DIFF
--- a/src/Month.js
+++ b/src/Month.js
@@ -151,15 +151,17 @@ class MonthView extends React.Component {
         </div>
         <div
           className={clsx(
-            'rbc-month-rows-container',
-            scrollableMonth && 'rbc-month-rows-container-scrollable'
+            'rbc-month-grid-container',
+            scrollableMonth && 'rbc-month-grid-container-scrollable'
           )}
           onScroll={this.handleScroll}
         >
           <div className="rbc-row rbc-month-header">
             {this.renderHeaders(weeks[0])}
           </div>
-          {weeks.map(renderWeekWithHeight)}
+          <div className="rbc-month-rows-container">
+            {weeks.map(renderWeekWithHeight)}
+          </div>
           {this.props.popup && this.renderOverlay()}
         </div>
       </div>

--- a/src/less/month.less
+++ b/src/less/month.less
@@ -43,14 +43,13 @@
   height: 100%; // ie-fix
 }
 
-.rbc-month-rows-container {
+.rbc-month-grid-container {
   display: flex;
   flex-direction: column;
   flex: 1 0 0;
 }
 
-.rbc-month-rows-container-scrollable {
-  display: block;
+.rbc-month-grid-container-scrollable {
   overflow-y: scroll;
 }
 
@@ -72,6 +71,10 @@
     transform: translateY(0);
     transition: opacity 0.5s ease-out, transform 0.3s ease-out;;
   }
+}
+
+.rbc-month-rows-container {
+  flex-grow: 1;
 }
 
 .rbc-month-row {

--- a/src/sass/month.scss
+++ b/src/sass/month.scss
@@ -42,14 +42,13 @@
   height: 100%; // ie-fix
 }
 
-.rbc-month-rows-container {
+.rbc-month-grid-container {
   display: flex;
   flex-direction: column;
   flex: 1 0 0;
 }
 
-.rbc-month-rows-container-scrollable {
-  display: block;
+.rbc-month-grid-container-scrollable {
   overflow-y: scroll;
 }
 
@@ -71,6 +70,10 @@
     transform: translateY(0);
     transition: opacity 0.5s ease-out, transform 0.3s ease-out;;
   }
+}
+
+.rbc-month-rows-container {
+  flex-grow: 1;
 }
 
 .rbc-month-row {


### PR DESCRIPTION
This fixes the bug where scrolling left and right creates a 1 px gap in the background sometimes.